### PR TITLE
API: api/users 매개변수 변경 및 내부 코드 문서화 (Closes #78)

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,69 +1,150 @@
-import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { Prisma } from "@prisma/client";
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 
-// JSON 형식으로 응답하는 도우미 함수
+/**
+ * JSON 응답 객체를 생성하는 유틸 함수
+ *
+ * @param data - 응답할 데이터 객체
+ * @param status - HTTP 상태 코드 (기본값: 200)
+ * @returns JSON 형식의 NextResponse 객체
+ */
 const jsonResponse = (data: any, status = 200) =>
   new NextResponse(JSON.stringify(data), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { 'Content-Type': 'application/json' },
   });
 
-// 유저 목록을 가져오는 GET 함수
+/**
+ * 엔드포인트 [`/api/users`]
+ *
+ * 사용자 목록을 조회하는 GET 메서드
+ *
+ * URL 매개변수로 필터링, 정렬, 페이징을 지원함.
+ *
+ * @param request - HTTP 요청 객체
+ * @returns 사용자 목록과 총 개수를 포함한 JSON 응답
+ */
 export async function GET(request: Request) {
-  // URL에서 쿼리 파라미터 추출
+  /* 
+  [`/api/users?page=0&limit=10&sort=idx&order=desc&email=hotmail.com` 에 대한 GET 요청 예시]
+  {
+    "rows": [
+      {
+        "idx": 324,
+        "name": "Haylee",
+        "email": "Hulda.Balistreri@hotmail.com",
+        "age": 9,
+        "visits": 169,
+        "progress": 29,
+        "status": "single",
+        "createdAt": "2025-04-16T02:24:00.039Z"
+      },
+      {
+        "idx": 321,
+        "name": "Cordelia",
+        "email": "Domenica.Runolfsson@hotmail.com",
+        "age": 30,
+        "visits": 924,
+        "progress": 83,
+        "status": "single",
+        "createdAt": "2025-04-16T02:23:59.861Z"
+      }
+    ],
+    "count": 97
+  }
+  */
+  // #1. URL 매개변수 추출
   const url = new URL(request.url);
-  const page = url.searchParams.get("page");
-  const limit = url.searchParams.get("limit");
-  const sort = url.searchParams.get("sort");
-  const order = url.searchParams.get("order");
-  const filter = url.searchParams.get("filter");
+  const page = url.searchParams.get('page');
+  const limit = url.searchParams.get('limit');
+  const sort = url.searchParams.get('sort');
+  const order = url.searchParams.get('order');
+  const email = url.searchParams.get('email');
+  const name = url.searchParams.get('name');
+  const age = url.searchParams.get('age');
 
   try {
-    // Prisma를 사용해 데이터베이스에서 유저 정보를 조회
+    // #2. 사용자 목록 조회
     const users = await prisma.user.findMany({
       skip: page && limit ? Number(page) * Number(limit) : undefined,
       take: limit ? Number(limit) : undefined,
-      orderBy: sort ? { [sort]: order || "asc" } : undefined,
-      where: filter
-        ? ({
-            OR: [
-              { name: { contains: filter } },
-              { email: { contains: filter } },
-              { age: { equals: Number(filter) } },
-            ],
-          } as Prisma.UserWhereInput)
-        : undefined,
+      orderBy: sort ? { [sort]: order || 'asc' } : undefined,
+      where: {
+        ...(email && {
+          email: {
+            contains: email,
+            mode: 'insensitive',
+          } as Prisma.StringFilter,
+        }),
+        ...(name && {
+          name: { contains: name, mode: 'insensitive' } as Prisma.StringFilter,
+        }),
+        ...(age && { age: Number(age) }),
+      },
     });
 
-    const count = await prisma.user.count();
+    // #3. 필터된 전체 사용자 수 조회
+    const count = await prisma.user.count({
+      where: {
+        ...(email && {
+          email: {
+            contains: email,
+            mode: 'insensitive',
+          } as Prisma.StringFilter,
+        }),
+        ...(name && {
+          name: { contains: name, mode: 'insensitive' } as Prisma.StringFilter,
+        }),
+        ...(age && { age: Number(age) }),
+      },
+    });
+
     return jsonResponse({ rows: [...users], count });
   } catch (error: unknown) {
     return jsonResponse({ error: (error as Error).message }, 500);
   }
 }
 
-// 유저를 추가하는 POST 함수
+/**
+ * 새로운 사용자를 추가하는 POST 메서드
+ *
+ * @param request - HTTP 요청 객체 (JSON 본문 포함)
+ * @returns 생성된 사용자 정보 또는 에러 메시지
+ */
 export async function POST(request: Request) {
   try {
     const json = await request.json();
+
     const user = await prisma.user.create({ data: json });
+
     return jsonResponse(user, 201);
   } catch (error: unknown) {
+    // 고유 키 충돌 처리
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === "P2002") {
-        return jsonResponse("User with email already exists", 409);
+      if (error.code === 'P2002') {
+        return jsonResponse(
+          '이미 해당 이메일로 등록된 사용자가 존재합니다',
+          409
+        );
       }
     }
+
     return jsonResponse({ error: (error as Error).message }, 500);
   }
 }
 
-// 유저 정보를 수정하는 PUT 함수
+/**
+ * 기존 사용자 정보를 수정하는 PUT 메서드
+ *
+ * @param request - HTTP 요청 객체 (JSON 본문 포함)
+ * @returns 수정된 사용자 정보 또는 에러 메시지
+ */
 export async function PUT(request: Request) {
   try {
     const json = await request.json();
     const { idx, email, age, visits, progress } = json;
+
     const user = await prisma.user.update({
       where: { idx: Number(idx) },
       data: {
@@ -73,20 +154,31 @@ export async function PUT(request: Request) {
         progress: Number(progress),
       },
     });
+
     return jsonResponse(user);
   } catch (error: unknown) {
     return jsonResponse({ error: (error as Error).message }, 500);
   }
 }
 
-// 유저를 삭제하는 DELETE 함수
+/**
+ * 사용자를 삭제하거나 모든 데이터를 리셋하는 DELETE 메서드
+ *
+ * @param request - HTTP 요청 객체 (본문에 idx 포함)
+ * @returns 삭제 결과 또는 에러 메시지
+ */
 export async function DELETE(request: Request) {
   try {
     const { idx } = JSON.parse(await request.text());
-    if (idx === "reset-data") {
+
+    // #1. 전체 초기화 처리
+    if (idx === 'reset-data') {
       await prisma.user.deleteMany({});
       return jsonResponse({});
-    } else if (idx) {
+    }
+
+    // #2. 단일 유저 삭제 처리
+    if (idx) {
       await prisma.user.delete({ where: { idx: Number(idx) } });
       return jsonResponse({});
     }


### PR DESCRIPTION
# `api/users` 매개변수 변경 및 문서화
<!-- 이 PR에 대한 요약 -->
`api/users` 엔드포인트의 매개변수 명세를 명확히 하고, 내부 문서화를 강화하였습니다.

## ✨ 주요 개발내역
<!-- PR 소속 커밋의 주 변경점 등 -->
- **매개변수 구조 명확화**
  - 기존의 모호한 단일 매개변수 `filter`를 제거하고, 다음과 같이 명확하게 분리하였습니다.
    - **`name`** (부분 일치)
    - **`email`** (부분 일치)
    - **`age`** (정확히 일치)  

- **내부 문서화 강화**
  - API 핸들러 내부에 **JSDoc 주석을 작성**하고, 필드별 설명 및 타입 명세를 추가하였습니다.
  - 코드 가독성과 유지보수성을 높이는 방향으로 주석을 보강하였습니다.

## 🖼️ 관련 스크린샷
<!-- 가능하다면, 대상 부분을 이미지 등으로 캡처하여 기록 남기기 -->
<!-- <p align="center"></p> 등으로 캡션 달아주기 -->

![image](https://github.com/user-attachments/assets/caf8d186-abe7-42ec-a62e-41276b653900)
<p align="center">API 변경하였으나, 이상 없이 잘 동작하는 모습</p> 

![image](https://github.com/user-attachments/assets/fa2c96d5-b126-44ba-bd93-bb2d2576ab83)
<p align="center"><code>http://localhost:3000/api/users?page=0&limit=2&sort=idx&order=desc&email=hotmail.com</code> 으로의 GET 요청 예시</p> 

## 🔗 관련 이슈
- This PR will close issue #78.

리뷰 및 피드백 부탁드립니다! 🙇‍♂️
