### PR TITLE
[Feature] 사용자 테이블 컬럼 정렬 기능 구현완료

### DIFF
--- a/src/components/store/SampleTableState.ts
+++ b/src/components/store/SampleTableState.ts
@@ -10,6 +10,8 @@ export interface ISampleTableState {
   pageSize: number; // 한 페이지당 표시될 행의 수
   pageIndex: number; // 현재 페이지 인덱스
   pageCount: number; // 전체 페이지 수
+  sortBy: keyof User; // 정렬 기준 컬럼 (예: name, email, createdAt 등)
+  sortOrder: 'asc' | 'desc'; // 오름차순 또는 내림차순
   refetch: () => void; // 데이터를 다시 가져오기 위한 함수
 }
 
@@ -23,6 +25,8 @@ export const sampleTableState = atom<ISampleTableState>({
     pageSize: 10,
     pageIndex: 0,
     pageCount: 0,
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
     refetch: () => null,
   },
 });

--- a/src/components/ui/ModifyDialog.tsx
+++ b/src/components/ui/ModifyDialog.tsx
@@ -120,26 +120,26 @@ const ModifyDialog = ({ user }: ModifyDialogProps) => {
               register={register}
             />
             <InputField
-              defaultValue={age}
+              defaultValue={age ||0}
               label="나이"
               name="age"
               register={register}
             />
             <InputField
-              defaultValue={visits}
+              defaultValue={visits || 0}
               label="방문횟수"
               name="visits"
               register={register}
             />
             <InputField
-              defaultValue={progress}
+              defaultValue={progress || 0}
               label="진행률"
               name="progress"
               register={register}
             />
             <InputField
               disabled
-              defaultValue={status}
+              defaultValue={status || ''}
               label="상태"
               name="status"
             />

--- a/src/components/ui/SampleTable.tsx
+++ b/src/components/ui/SampleTable.tsx
@@ -66,6 +66,7 @@ type UserData = {
 export const SampleTable = ({ initialData }: Props) => {
   const [tableState, setTableState] = useRecoilState(sampleTableState);
   const { rows, pageSize, pageIndex } = tableState;
+  const { sortBy, sortOrder } = tableState;
   const { data, isError, isLoading, isFetching, isFetched, refetch } =
     useQuery<UserData>({
       queryKey: [
@@ -74,8 +75,10 @@ export const SampleTable = ({ initialData }: Props) => {
           queryParams: {
             page: pageIndex,
             limit: pageSize,
-            sort: 'createdAt',
-            order: 'desc',
+            // sort: 'createdAt',
+            // order: 'desc',
+            sort: sortBy,
+            order: sortOrder,
           },
         },
       ],
@@ -178,22 +181,48 @@ SampleTable.displayName = 'SampleTable';
 
 // 테이블 헤더 부분을 렌더링하는 컴포넌트
 const SampleTableHeader = ({ table }: { table: TableType<User> }) => {
+  const [tableState, setTableState] = useRecoilState(sampleTableState);
+  const { sortBy, sortOrder } = tableState;
+
+  // 정렬 핸들러 함수
+  const handleSort = (columnId: string) => {
+    if (sortBy === columnId) {
+      // 이미 정렬된 컬럼이라면 방향만 토글
+      const newOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+      setTableState((prev) => ({ ...prev, sortOrder: newOrder }));
+    } else {
+      // 새 컬럼 클릭 시 정렬 기준 변경
+      setTableState((prev) => ({
+        ...prev,
+        sortBy: columnId as keyof User,
+        sortOrder: 'asc', // 초기 정렬 방향은 asc
+      }));
+    }
+  };
+
   return (
     <TableHeader className="sticky top-0 bg-gray-700 text-white dark:bg-slate-800">
       {table.getHeaderGroups().map((headerGroup) => (
         <TableRow key={headerGroup.id}>
           {headerGroup.headers.map((header) => {
+            const columnId = header.column.id;
+            const isSortedColumn = sortBy === columnId;
+
             return (
               <TableHead
                 key={header.id}
-                className="text-center"
+                className="text-center cursor-pointer select-none"
                 colSpan={header.colSpan}
+                onClick={() => handleSort(columnId)}
               >
                 {header.isPlaceholder ? null : (
-                  <div>
+                  <div className="flex items-center justify-center gap-1">
                     {flexRender(
                       header.column.columnDef.header,
                       header.getContext()
+                    )}
+                    {isSortedColumn && (
+                      <span>{sortOrder === 'asc' ? '▲' : '▼'}</span>
                     )}
                   </div>
                 )}
@@ -205,6 +234,7 @@ const SampleTableHeader = ({ table }: { table: TableType<User> }) => {
     </TableHeader>
   );
 };
+
 
 // 테이블 바디 부분을 렌더링하는 컴포넌트
 const SampleTableBody = ({ table }: { table: TableType<User> }) => {


### PR DESCRIPTION
## #️⃣ Relationship Issues
[#82 사용자 목록 정렬 기능 추가](https://github.com/ATG-AMS/ams-next-boilerplate/issues/82)

## 💡 Key Changes

- 전체적인 흐름 : 프론트엔드에서 테이블 헤더를 클릭했을 때 정렬 기준과 방향(sortBy, sortOrder)이 변경되고, 이 정보가 API 요청의 URL 쿼리 파라미터로 전송되어 백엔드가 해당 기준에 따라 정렬된 데이터를 응답하도록 한다는 흐름입니다.

          [유저가 테이블 헤더 클릭]
              ↓
          [Recoil 상태 변경: sortBy, sortOrder]
              ↓
          [API 요청 쿼리로 전달]
              ↓
          [백엔드가 해당 정렬 기준으로 DB 조회]
              ↓
          [프론트에 정렬된 데이터 전달 → 테이블 렌더링]


기본정렬은 생성시각 입니다.
![image](https://github.com/user-attachments/assets/1f4eaa06-5e6e-421b-a32a-d1951b3f1b2c)

순번으로 정렬한 화면입니다.
![image](https://github.com/user-attachments/assets/72c470a8-9e07-4efb-9720-ea97143c953a)

정렬 기준을 유지하며 페이지를 이동합니다.
![image](https://github.com/user-attachments/assets/a509ff29-436d-42da-aa5d-eea8c2120463)



-  백엔드
이미 정렬, 필터링, 페이징 기능이 구현되어 있었고 SampleTableHeader에서 정렬 상태를 전역으로 관리하며, 해당 상태를 기반으로 API 요청을 만들면 서버는 이미 그 조건에 맞게 응답해줍니다.
프론트엔드에서 테이블 헤더를 클릭했을 때 정렬 기준과 방향(sortBy, sortOrder)이 변경되고, 이 정보가 API 요청의 URL 쿼리 파라미터로 전송되어 백엔드가 해당 기준에 따라 정렬된 데이터를 응답하는 흐름입니다.
GET 요청에서 정렬 기준(sort), 정렬 방향(order)을 query param으로 받을 수 있도록 구현되어 있는 것을 활용하여 Prisma의 orderBy를 동적으로 설정하여 전체 데이터셋 기준 정렬 가능하게 처리합니다.


- 프론트엔드
테이블 헤더 클릭 시, 해당 컬럼으로 정렬 기준을 토글하는 UI/UX를 구현하였습니다.
Recoil 상태(sortBy, sortOrder)로 정렬 기준/방향을 전역 관리합니다.
정렬 핸들러 함수를 사용하여 현재 선택된 컬럼을 다시 누르면 방향이 바뀌게 구현하여 사용자로 하여금 즉각 정렬 결과를 제공합니다.

- 테스트 시나리오






## ➕ ETC

- 테이블 헤더 UI는 클릭 시 정렬 방향을 ▲▼ 화살표로 표시하였습니다.

- 최초 진입 시에는 전체 리스트가 생성 시각 기준으로 표시했습니다.

- 정렬된 상태에서 페이지를 이동해도 상태가 유지됩니다. (쿼리 기반 API 요청)
