### PR TITLE
메인 페이지 '단일 사용자 추가 기능' 추가 등

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^8.0.2",
+    "@hookform/resolvers": "5.0.1",
     "@prisma/client": "^5.11.0",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",
@@ -44,9 +45,11 @@
     "sharp": "0.33.2",
     "sqlite": "^5.0.1",
     "sqlite3": "^5.1.6",
+    "sweetalert2": "11.19.1",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "3.4.1",
-    "typescript": "5.4.3"
+    "typescript": "5.4.3",
+    "zod": "3.24.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/src/components/ui/FunctionButtons.tsx
+++ b/src/components/ui/FunctionButtons.tsx
@@ -12,7 +12,7 @@ import { useForm } from 'react-hook-form';
 import { useRecoilState } from 'recoil';
 import { sampleTableState } from '@/components/store/SampleTableState';
 import { SingleUserDialog } from './single-user-dialog';
-import { swalDialog, swalToast } from '@/lib/swal';
+import { swalToast } from '@/lib/swal';
 
 // 도구 툴바 컴포넌트. 데이터 생성 및 초기화 버튼을 포함
 export const FunctionToolbar = ({ className }: { className?: string }) => {
@@ -52,14 +52,24 @@ export const FunctionToolbar = ({ className }: { className?: string }) => {
             'success'
           );
         },
-        onError: (error) => {
-          console.error('사용자 추가 중 에러 발생:', error);
-          swalToast(
-            '사용자 추가 실패',
-            '사용자 추가에 실패했습니다. 이메일 중복 여부 등을 확인한 후 다시 시도해주세요.',
-            'error',
-            5000
-          );
+        onError: (error: any) => {
+          console.error('사용자 추가 중 에러 발생:', error.response);
+          // HTTP 409 Conflict (이메일 중복)
+          if (error?.status === 409) {
+            swalToast(
+              '사용자 추가 실패',
+              '이미 해당 이메일로 가입된 사용자가 존재합니다.',
+              'error',
+              5000
+            );
+          } else {
+            swalToast(
+              '사용자 추가 실패',
+              '사용자 추가에 실패했습니다. 다시 시도해주세요.',
+              'error',
+              5000
+            );
+          }
         },
       }
     );

--- a/src/components/ui/FunctionButtons.tsx
+++ b/src/components/ui/FunctionButtons.tsx
@@ -12,14 +12,13 @@ import { useForm } from 'react-hook-form';
 import { useRecoilState } from 'recoil';
 import { sampleTableState } from '@/components/store/SampleTableState';
 import { SingleUserDialog } from './single-user-dialog';
-import { swalToast } from '@/lib/swal';
 
 // 도구 툴바 컴포넌트. 데이터 생성 및 초기화 버튼을 포함
 export const FunctionToolbar = ({ className }: { className?: string }) => {
   const [tableState, setTableState] = useRecoilState(sampleTableState);
   const [showAddDialog, setShowAddDialog] = useState(false);
   const { refetch } = tableState;
-  const { mutate, status } = useMutation({ mutationFn: fetchC });
+  const { mutateAsync, status } = useMutation({ mutationFn: fetchC });
 
   // 첫 번째 페이지로 되돌리는 함수
   const resetToFirstPage = () => {
@@ -27,7 +26,7 @@ export const FunctionToolbar = ({ className }: { className?: string }) => {
   };
 
   // 단일 사용자 수동 추가 폼 제출 핸들러
-  const onSingleUserFormSubmit = (data: any) => {
+  const onSingleUserFormSubmit = async (data: any) => {
     const transformedData = {
       ...data,
       age: data.age ? Number(data.age) : undefined,
@@ -35,44 +34,11 @@ export const FunctionToolbar = ({ className }: { className?: string }) => {
       progress: data.progress ? Number(data.progress) : undefined,
     };
 
-    mutate(
-      {
-        endpoint: 'users',
-        method: 'POST',
-        body: transformedData,
-      },
-      {
-        onSuccess: () => {
-          setShowAddDialog(false);
-          refetch();
-          resetToFirstPage();
-          swalToast(
-            '사용자 추가 성공',
-            '사용자가 성공적으로 추가되었습니다.',
-            'success'
-          );
-        },
-        onError: (error: any) => {
-          console.error('사용자 추가 중 에러 발생:', error.response);
-          // HTTP 409 Conflict (이메일 중복)
-          if (error?.status === 409) {
-            swalToast(
-              '사용자 추가 실패',
-              '이미 해당 이메일로 가입된 사용자가 존재합니다.',
-              'error',
-              5000
-            );
-          } else {
-            swalToast(
-              '사용자 추가 실패',
-              '사용자 추가에 실패했습니다. 다시 시도해주세요.',
-              'error',
-              5000
-            );
-          }
-        },
-      }
-    );
+    return mutateAsync({
+      endpoint: 'users',
+      method: 'POST',
+      body: transformedData,
+    });
   };
 
   return (

--- a/src/components/ui/FunctionButtons.tsx
+++ b/src/components/ui/FunctionButtons.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/atoms/Button';
 import { cn, fetchC } from '@/lib/utils';
 import { useMutation } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Person } from '@/lib/makeData';
 import { makeData } from '@/lib/makeData';
 import { Input } from '@/components/atoms/Input';
@@ -11,15 +11,58 @@ import { Label } from '@/components/atoms/Label';
 import { useForm } from 'react-hook-form';
 import { useRecoilState } from 'recoil';
 import { sampleTableState } from '@/components/store/SampleTableState';
+import { SingleUserDialog } from './single-user-dialog';
+import { swalDialog, swalToast } from '@/lib/swal';
 
 // 도구 툴바 컴포넌트. 데이터 생성 및 초기화 버튼을 포함
 export const FunctionToolbar = ({ className }: { className?: string }) => {
   const [tableState, setTableState] = useRecoilState(sampleTableState);
+  const [showAddDialog, setShowAddDialog] = useState(false);
   const { refetch } = tableState;
+  const { mutate, status } = useMutation({ mutationFn: fetchC });
 
   // 첫 번째 페이지로 되돌리는 함수
   const resetToFirstPage = () => {
     setTableState((prev) => ({ ...prev, pageIndex: 0 }));
+  };
+
+  // 단일 사용자 수동 추가 폼 제출 핸들러
+  const onSingleUserFormSubmit = (data: any) => {
+    const transformedData = {
+      ...data,
+      age: data.age ? Number(data.age) : undefined,
+      visits: data.visits ? Number(data.visits) : undefined,
+      progress: data.progress ? Number(data.progress) : undefined,
+    };
+
+    mutate(
+      {
+        endpoint: 'users',
+        method: 'POST',
+        body: transformedData,
+      },
+      {
+        onSuccess: () => {
+          setShowAddDialog(false);
+          refetch();
+          resetToFirstPage();
+          swalToast(
+            '사용자 추가 성공',
+            '사용자가 성공적으로 추가되었습니다.',
+            'success'
+          );
+        },
+        onError: (error) => {
+          console.error('사용자 추가 중 에러 발생:', error);
+          swalToast(
+            '사용자 추가 실패',
+            '사용자 추가에 실패했습니다. 이메일 중복 여부 등을 확인한 후 다시 시도해주세요.',
+            'error',
+            5000
+          );
+        },
+      }
+    );
   };
 
   return (
@@ -28,6 +71,12 @@ export const FunctionToolbar = ({ className }: { className?: string }) => {
         className="border-r border-gray-400"
         refetch={refetch}
         syncState={resetToFirstPage}
+      />
+      <SingleUserDialog
+        isCreate={true}
+        isOpen={showAddDialog}
+        setIsOpen={setShowAddDialog}
+        onSubmit={onSingleUserFormSubmit}
       />
       <ResetButton refetch={refetch} syncState={resetToFirstPage} />
     </div>

--- a/src/components/ui/single-user-dialog.tsx
+++ b/src/components/ui/single-user-dialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/atoms/Dialog';
+import { swalToast } from '@/lib/swal';
 
 // #1. 이 파일 내에서 사용할 타입 및 인터페이스 정의
 interface UserDialogProps {
@@ -87,6 +88,7 @@ export const SingleUserDialog = ({
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<User>({
     defaultValues: user || {
@@ -99,6 +101,31 @@ export const SingleUserDialog = ({
     },
     ...formOptions,
   });
+
+  const handleFormSubmit = async (data: User) => {
+    try {
+      await onSubmit(data);
+      setIsOpen(false);
+      swalToast(
+        '사용자 추가 성공',
+        '사용자가 성공적으로 추가되었습니다.',
+        'success'
+      );
+    } catch (error: any) {
+      if (error.status === 409) {
+        setError('email', {
+          type: 'server',
+          message: '이미 해당 이메일로 가입된 사용자가 존재합니다.',
+        });
+      } else {
+        swalToast(
+          '사용자 추가 실패',
+          '사용자 추가에 실패했습니다. 다시 시도해주세요.',
+          'error'
+        );
+      }
+    }
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -116,7 +143,7 @@ export const SingleUserDialog = ({
               : '아래 정보 중 수정 가능한 것들을 수정할 수 있습니다.'}
           </DialogDescription>
         </DialogHeader>
-        <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
+        <form className="space-y-4" onSubmit={handleSubmit(handleFormSubmit)}>
           <div>
             <Label htmlFor="name">
               이름 <span className="text-orange-400">*</span>

--- a/src/components/ui/single-user-dialog.tsx
+++ b/src/components/ui/single-user-dialog.tsx
@@ -89,6 +89,7 @@ export const SingleUserDialog = ({
     register,
     handleSubmit,
     setError,
+    reset,
     formState: { errors },
   } = useForm<User>({
     defaultValues: user || {
@@ -106,6 +107,7 @@ export const SingleUserDialog = ({
     try {
       await onSubmit(data);
       setIsOpen(false);
+      reset();
       swalToast(
         '사용자 추가 성공',
         '사용자가 성공적으로 추가되었습니다.',
@@ -223,7 +225,13 @@ export const SingleUserDialog = ({
           </div>
           <DialogFooter>
             <Button type="submit">사용자 {isCreate ? '추가' : '수정'}</Button>
-            <Button type="button" onClick={() => setIsOpen(false)}>
+            <Button
+              type="button"
+              onClick={() => {
+                setIsOpen(false);
+                reset();
+              }}
+            >
               취소
             </Button>
           </DialogFooter>

--- a/src/components/ui/single-user-dialog.tsx
+++ b/src/components/ui/single-user-dialog.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+// #0. 사용할 라이브러리 등 Import
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@/components/atoms/Button';
+import { Label } from '@/components/atoms/Label';
+import { Input } from '@/components/atoms/Input';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/atoms/Dialog';
+
+// #1. 이 파일 내에서 사용할 타입 및 인터페이스 정의
+interface UserDialogProps {
+  user?: User | null;
+  isCreate?: boolean; // true: 사용자 추가, false: 사용자 수정
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onSubmit: (data: User) => void;
+}
+interface User {
+  idx?: number;
+  name: string;
+  email: string;
+  age?: number;
+  visits?: number;
+  progress?: number;
+  status?: string;
+  createdAt?: Date | string;
+}
+
+// #2. 유효성 검사 (Zod 사용)
+const userSchema = z.object({
+  name: z.string().min(1, '이름은 필수 입력 항목입니다.'),
+  email: z.string().email('유효한 이메일 주소를 입력해 주세요.'),
+  age: z
+    .union([
+      z
+        .number()
+        .int('나이는 자연수로 입력하거나, 비워놓으세요.')
+        .positive('나이는 자연수로 입력하거나, 비워놓으세요.')
+        .min(1),
+      z.nan(),
+    ])
+    .optional(),
+  visits: z
+    .union([
+      z
+        .number()
+        .int('방문 횟수는 자연수로 입력하거나, 비워놓으세요.')
+        .nonnegative('방문 횟수는 자연수로 입력하거나, 비워놓으세요.'),
+      z.nan(),
+    ])
+    .optional(),
+  progress: z
+    .union([
+      z
+        .number()
+        .int('방문 횟수는 0~100의 정수 값으로 입력하거나, 비워놓으세요.')
+        .min(0, '방문 횟수는 0~100의 정수 값으로 입력하거나, 비워놓으세요.')
+        .max(100, '방문 횟수는 0~100의 정수 값으로 입력하거나, 비워놓으세요.'),
+      z.nan(),
+    ])
+    .optional(),
+  status: z.string().optional(),
+});
+
+const formOptions = {
+  resolver: zodResolver(userSchema),
+};
+
+// #3. 사용자 정보 추가 및 수정 대화 상자 컴포넌트 정의
+export const SingleUserDialog = ({
+  user = null,
+  isCreate = true,
+  isOpen,
+  setIsOpen,
+  onSubmit,
+}: UserDialogProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<User>({
+    defaultValues: user || {
+      name: '',
+      email: '',
+      age: undefined,
+      visits: undefined,
+      progress: undefined,
+      status: undefined,
+    },
+    ...formOptions,
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button onClick={() => setIsOpen(true)}>
+          {isCreate ? '사용자 추가' : '사용자 수정'}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="bg-slate-900 text-white">
+        <DialogHeader>
+          <DialogTitle>{isCreate ? '사용자 추가' : '사용자 수정'}</DialogTitle>
+          <DialogDescription>
+            {isCreate
+              ? '아래에 정보를 입력하여 사용자를 추가하세요.'
+              : '아래 정보 중 수정 가능한 것들을 수정할 수 있습니다.'}
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
+          <div>
+            <Label htmlFor="name">
+              이름 <span className="text-orange-400">*</span>
+            </Label>
+            <Input
+              {...register('name')}
+              disabled={!isCreate}
+              id="name"
+              placeholder="이름 입력 (예: 홍길동)"
+              type="text"
+            />
+            {errors.name && (
+              <span className="text-red-500">{errors.name.message}</span>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="email">
+              이메일 주소 <span className="text-orange-400">*</span>
+            </Label>
+            <Input
+              {...register('email')}
+              id="email"
+              placeholder="이메일 입력 (예: example@example.com)"
+              type="email"
+            />
+            {errors.email && (
+              <span className="text-red-500">{errors.email.message}</span>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="age">나이</Label>
+            <Input
+              {...register('age', { valueAsNumber: true })}
+              id="age"
+              placeholder="나이 입력 (예: 27)"
+              type="number"
+            />
+            {errors.age && (
+              <span className="text-red-500">{errors.age.message}</span>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="visits">방문 횟수</Label>
+            <Input
+              {...register('visits', { valueAsNumber: true })}
+              id="visits"
+              placeholder="방문 횟수 입력 (예: 5)"
+              type="number"
+            />
+            {errors.visits && (
+              <span className="text-red-500">{errors.visits.message}</span>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="progress">진행률</Label>
+            <Input
+              {...register('progress', { valueAsNumber: true })}
+              id="progress"
+              placeholder="진행률 입력 (예: 50)"
+              type="number"
+            />
+            {errors.progress && (
+              <span className="text-red-500">{errors.progress.message}</span>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="status">상태</Label>
+            <Input
+              {...register('status')}
+              id="status"
+              placeholder="상태 입력 (예: single)"
+              type="text"
+            />
+            {errors.status && (
+              <span className="text-red-500">{errors.status.message}</span>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="submit">사용자 {isCreate ? '추가' : '수정'}</Button>
+            <Button type="button" onClick={() => setIsOpen(false)}>
+              취소
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/lib/swal.ts
+++ b/src/lib/swal.ts
@@ -1,0 +1,132 @@
+import Swal, { type SweetAlertOptions } from 'sweetalert2';
+
+// 아이콘 타입에 따른 버튼 색상 매핑
+const buttonColors: Record<string, string> = {
+  success: '#28a745', // 초록색
+  error: '#dc3545', // 빨간색
+  warning: '#ffc107', // 주황색
+  info: '#17a2b8', // 파란색
+  question: '#6c757d', // 회색
+};
+
+/**
+ * 기본적인 SweetAlert2 옵션
+ * @constant {SweetAlertOptions}
+ */
+export const DEFAULT_TOAST_OPTIONS: SweetAlertOptions = {
+  timerProgressBar: true,
+  showConfirmButton: true,
+  theme: 'auto',
+};
+
+/**
+ * 기본 다이얼로그.
+ * - 간단한 메시지를 알림으로 표시.
+ *
+ * @param {string} title 다이얼로그 제목.
+ * @param {string} text 다이얼로그 본문 텍스트.
+ * @param {'success' | 'error' | 'warning' | 'info' | 'question'} icon 아이콘 타입
+ */
+export function swalDialog(
+  title: string,
+  text: string,
+  icon: 'success' | 'error' | 'warning' | 'info' | 'question'
+) {
+  Swal.fire({
+    ...DEFAULT_TOAST_OPTIONS,
+    title,
+    icon,
+    text,
+    confirmButtonColor: buttonColors[icon], // 아이콘에 맞는 버튼 색상 적용
+  } as SweetAlertOptions);
+}
+
+/**
+ * 확인/취소 다이얼로그.
+ * - 사용자의 선택을 확인해야 할 때 사용.
+ *
+ * @param {string} title 다이얼로그 제목.
+ * @param {string} text 다이얼로그 본문 텍스트.
+ * @param {'success' | 'error' | 'warning' | 'info' | 'question'} icon 아이콘 타입.
+ * @param {string} confirmButtonText 확인 버튼 텍스트.
+ * @param {string} cancelButtonText 취소 버튼 텍스트.
+ * @param {(result: boolean) => void} callback 사용자의 선택 결과(`true`: 확인, `false`: 취소).
+ */
+export function swalConfirmDialog(
+  title: string,
+  text: string,
+  icon: 'success' | 'error' | 'warning' | 'info' | 'question',
+  confirmButtonText: string,
+  cancelButtonText: string,
+  callback: (result: boolean) => void
+) {
+  Swal.fire({
+    title,
+    icon,
+    text,
+    showCancelButton: true,
+    confirmButtonText,
+    cancelButtonText,
+    confirmButtonColor: buttonColors[icon], // 아이콘에 맞는 버튼 색상 적용
+  }).then((result) => {
+    callback(result.isConfirmed);
+  });
+}
+
+/**
+ * 토스트 메시지.
+ * - 화면 우측 하단에 작은 메시지를 띄움.
+ *
+ * @param {string} title 토스트 제목.
+ * @param {string} text 토스트 본문 텍스트.
+ * @param {'success' | 'error' | 'warning' | 'info' | 'question'} icon 아이콘 타입.
+ * @param {number} [timer=3000] ms(밀리세컨드) 단위의 자동 닫힘 시간(기본값: 3000ms).
+ */
+export function swalToast(
+  title: string,
+  text: string,
+  icon: 'success' | 'error' | 'warning' | 'info' | 'question',
+  timer: number = 3000
+) {
+  Swal.fire({
+    ...DEFAULT_TOAST_OPTIONS,
+    title,
+    text,
+    icon,
+    toast: true,
+    position: 'bottom-end',
+    showConfirmButton: false,
+    timer,
+  });
+}
+
+/**
+ * 입력 다이얼로그.
+ * 사용자 입력을 받을 때 사용.
+ *
+ * @param {string} title 다이얼로그 제목.
+ * @param {'text' | 'email' | 'password' | 'number'} inputType 입력 타입.
+ * @param {string} placeholder 입력 필드의 플레이스홀더.
+ * @param {string} confirmButtonText 확인 버튼 텍스트.
+ * @param {string} cancelButtonText 취소 버튼 텍스트.
+ * @param {(inputValue: string | null) => void} callback 사용자가 입력한 값 (취소 시 `null` 반환).
+ */
+export function swalPrompt(
+  title: string,
+  inputType: 'text' | 'email' | 'password' | 'number',
+  placeholder: string,
+  confirmButtonText: string,
+  cancelButtonText: string,
+  callback: (inputValue: string | null) => void
+) {
+  Swal.fire({
+    title,
+    input: inputType,
+    inputPlaceholder: placeholder,
+    showCancelButton: true,
+    confirmButtonText,
+    cancelButtonText,
+  }).then((result) => {
+    callback(result.value ?? null);
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,9 @@
-import localFont from "next/font/local";
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import localFont from 'next/font/local';
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export const SUIT = localFont({
-  src: "../../public/fonts/SUIT/SUIT-Variable.woff2",
+  src: '../../public/fonts/SUIT/SUIT-Variable.woff2',
 });
 
 export function cn(...inputs: ClassValue[]) {
@@ -12,7 +12,7 @@ export function cn(...inputs: ClassValue[]) {
 
 interface ServerSideFetchOptions {
   endpoint: string;
-  method?: "GET" | "POST" | "PUT" | "DELETE";
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   queryParams?: Record<string, string | number>;
   header?: Record<string, string>;
   body?: any;
@@ -28,14 +28,14 @@ export const fetchS = async (options: ServerSideFetchOptions) => {
   // const headers: Record<string, string> =
   //   options.header || createHeaders(token);
 
-  if (options.method === "POST" || options.method === "PUT") {
-    if (!headers["Content-Type"]) {
-      headers["Content-Type"] = "application/json";
+  if (options.method === 'POST' || options.method === 'PUT') {
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
     }
   }
 
   const response = await fetch(url.toString(), {
-    method: options.method || "GET",
+    method: options.method || 'GET',
     headers: headers,
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
@@ -43,7 +43,7 @@ export const fetchS = async (options: ServerSideFetchOptions) => {
   if (!response.ok) {
     const errorData = await response.json();
     throw new Error(
-      `API Error: ${response.statusText} - ${errorData.message || ""}`,
+      `API Error: ${response.statusText} - ${errorData.message || ''}`
     );
   }
 
@@ -57,24 +57,24 @@ export function formatDate(input: string | number | Date): string {
   } else {
     date = input;
   }
-  return date.toLocaleDateString("ko-KR", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
+  return date.toLocaleDateString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
   });
 }
 
 export interface ClientSideFetchOptions {
   endpoint: string;
   // token: string;
-  method?: "GET" | "POST" | "PUT" | "DELETE";
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   queryParams?: Record<string, string | number>;
   header?: Record<string, string>;
   body?: any;
 }
 
 export const fetchC = async (options: ClientSideFetchOptions) => {
-  console.log("🚀 ~ fetchC ~ ClientSide ~ options:", options);
+  console.log('🚀 ~ fetchC ~ ClientSide ~ options:', options);
   // if (!token) {
   //   throw new Error("Token is not provided");
   // }
@@ -91,24 +91,27 @@ export const fetchC = async (options: ClientSideFetchOptions) => {
   //   options.header || createHeaders(token);
 
   // POST, PUT 메소드일 경우 Content-Type을 지정한다.
-  if (options.method === "POST" || options.method === "PUT") {
+  if (options.method === 'POST' || options.method === 'PUT') {
     // Content-Type이 없으면 기본값을 사용한다.
-    if (!headers["Content-Type"]) {
-      headers["Content-Type"] = "application/json";
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
     }
   }
 
   const response = await fetch(url.toString(), {
-    method: options.method || "GET",
+    method: options.method || 'GET',
     headers: headers,
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
 
   if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(
-      `API Error: ${response.statusText} - ${errorData.message || ""}`,
-    );
+    const errorData = await response.json().catch(() => ({})); // JSON 파싱 실패 시 빈 객체 반환
+    throw {
+      status: response.status,
+      statusText: response.statusText,
+      message: errorData.message || 'Unknown error occurred',
+      data: errorData,
+    };
   }
 
   return await response.json();
@@ -116,29 +119,29 @@ export const fetchC = async (options: ClientSideFetchOptions) => {
 
 const createQueryParams = (
   urlObj: URL,
-  queryParams: Record<string, string | number>,
+  queryParams: Record<string, string | number>
 ) => {
   Object.keys(queryParams).forEach((key) =>
-    urlObj.searchParams.append(key, String(queryParams![key])),
+    urlObj.searchParams.append(key, String(queryParams![key]))
   );
 };
 
 const createHeaders = (token: string) => ({
-  "X-Authorization": `Bearer ${token}`,
-  "X-Requested-With": "XMLHttpRequest",
+  'X-Authorization': `Bearer ${token}`,
+  'X-Requested-With': 'XMLHttpRequest',
 });
 
 export type RequestParams = {
   endpoint?: string;
   queryParams?: Record<string, string | number>;
-  method?: "GET" | "POST" | "PUT" | "DELETE";
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
   body?: any;
   headers?: Record<string, string>;
 };
 
 // Partial<RequestParams> : RequestParams의 모든 속성을 선택적으로 만듬
 export function parseRequestParams(
-  arr: Array<Partial<RequestParams>>,
+  arr: Array<Partial<RequestParams>>
 ): RequestParams {
   const result: RequestParams = {};
 


### PR DESCRIPTION
# 메인 페이지 '단일 사용자 추가 기능' 추가 등
사용자 추가 기능을 도입하고, 폼 구성 및 알림 기능을 위한 리팩토링을 진행하였습니다.

## ✨ 주요 개발내역
- **단일 사용자 수동 추가 기능**
  - 메인 페이지에 **'사용자 추가' 버튼을 새로 추가**하였습니다.
  - 버튼 클릭 시, **사용자 추가 또는 수정이 가능한 컴포넌트가 열리는 구조로 설계**하였습니다.
    - 재사용성을 위해 추가 또는 수정 모두에 대응이 되게 개발하였고, 이 페이지에서는 '추가'로서만 동작합니다.

- **'사용자 추가 및 수정' 컴포넌트 개발**
  - **React Hook Form**을 사용하여 폼 상태를 관리하고,
  - **Zod를 이용한 유효성 검사 로직을 적용**하였습니다.

- **알림 유틸 추가**
  - `@lib/swal.ts` 파일을 추가하여 **SweetAlert2 기반의 알림 유틸리티를 구성**하였습니다.

## 🖼️ 관련 스크린샷

![스크린샷 2025-04-25 152013](https://github.com/user-attachments/assets/457d1952-4d6c-4d36-ad9f-8c0108981846)
<p align="center">성공적으로 사용자가 등록된 경우 (자동 Refetch)</p>

![스크린샷 2025-04-25 165444](https://github.com/user-attachments/assets/17b820bd-e263-4780-b1d4-d4a0fdbccc85)
<p align="center">이메일 중복 등으로 사용자 등록에 실패하는 경우</p>

## 🔗 관련 이슈
- Radix Dialog와 Z-Index 충돌 이슈가 있어, 향후 **Radix Alert로 대체**하는 방안도 고려해보면 좋을 것 같습니다.
  - 렌더링 자체는 SweetAlert2 컴포넌트가 Radix Dialog 보다 더 위에 되나, 클릭 이벤트 등을 뺏어가는 등의 문제로 처리가 어렵습니다.

리뷰 및 피드백 부탁드립니다! 🙇‍♂️