### PR TITLE
[Bug] 사용자 테이블 정렬 수정(정렬 가능 표시, layout 안정화)

### DIFF
--- a/src/components/ui/SampleTable.tsx
+++ b/src/components/ui/SampleTable.tsx
@@ -167,7 +167,7 @@ export const SampleTable = ({ initialData }: Props) => {
         </div>
 
         <div className="h-[36vh] overflow-auto">
-          <Table className="my-4" maxHeight="35vh">
+          <Table className="my-4" style={{ tableLayout: 'fixed', width: '100%' }}>
             <SampleTableHeader table={table} />
             <TableBody className="h-96 overflow-y-auto">
               {[...Array(EMPTY_ROWS)].map((_, index) => (
@@ -194,7 +194,7 @@ export const SampleTable = ({ initialData }: Props) => {
         <FunctionToolbar className="my-3 p-3" />
       </div>
       <div className="h-[36vh] overflow-auto">
-        <Table className="my-4" maxHeight="35vh">
+        <Table className="my-4" style={{ tableLayout: 'fixed', width: '100%' }}>
           <SampleTableHeader table={table} />
           <SampleTableBody table={table} />
         </Table>
@@ -247,9 +247,9 @@ const SampleTableHeader = ({ table }: { table: TableType<User> }) => {
                       header.column.columnDef.header,
                       header.getContext()
                     )}
-                    {isSortedColumn && (
-                      <span>{sortOrder === 'asc' ? '▲' : '▼'}</span>
-                    )}
+                    <span className="text-xs">
+                       {isSortedColumn ? (sortOrder === 'asc' ? '▲' : '▼') : '⇅'}
+                     </span>
                   </div>
                 )}
               </TableHead>
@@ -267,7 +267,7 @@ const SampleTableBody = ({ table }: { table: TableType<User> }) => {
     <TableBody className="h-96 overflow-y-auto">
       {table.getRowModel().rows.map((row) => {
         return (
-          <TableRow key={row.id}>
+          <TableRow key={row.id} className="min-h-[50px]">
             {row.getVisibleCells().map((cell) => {
               return (
                 <TableCell key={cell.id}>


### PR DESCRIPTION
## #️⃣ Relationship Issues
- https://github.com/ATG-AMS/ams-next-boilerplate/issues/89

## 💡 Key Changes

![Image](https://github.com/user-attachments/assets/71d49ed6-4ab6-4e96-98a3-3a05c3b3a14b)


**작업내용:**
- 정렬 가능 표시
모든 헤더에 기본 화살표 아이콘을 표기했고 정렬된 컬럼은 정렬상태를 유지하여 직관성을 높였습니다.

- 레이아웃 안정화


**버그원인:**

- 테이블 전체 데이터 다시 불러오면서 **table 높이**, **row 높이**, **스크롤바 유무**가 변하면서 레이아웃이 뒤틀렸습니다.
- 그리고 Header/Body가 width 맞지 않거나, reflow가 생겨서 흔들리는 현상이 발생했습니다.

**해결방법:**

- **테이블 height를 고정값**으로 설정했습니다.
- **각 row의 최소 높이(min-height)** 를 고정했습니다.


## ➕ ETC

